### PR TITLE
feat: support --iteration-id in story update

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ tapd story list
 # 创建需求
 tapd story create --name "新功能需求"
 
+# 更新需求并切换迭代
+tapd story update 10001 --iteration-id 12345
+
 # 查询缺陷列表
 tapd bug list
 

--- a/internal/cmd/story.go
+++ b/internal/cmd/story.go
@@ -98,6 +98,7 @@ func init() {
 	storyUpdateCmd.Flags().StringVar(&flagStatus, "status", "", "新状态（用 workflow status-map 查询可用值）")
 	storyUpdateCmd.Flags().StringVar(&flagOwner, "owner", "", "新处理人")
 	storyUpdateCmd.Flags().StringVar(&flagPriority, "priority", "", "新优先级（High/Middle/Low/Nice To Have）")
+	storyUpdateCmd.Flags().StringVar(&flagIterationID, "iteration-id", "", "新迭代 ID")
 
 	storyCountCmd.Flags().StringVar(&flagStatus, "status", "", "按状态筛选（用 workflow status-map 查询可用值）")
 
@@ -204,6 +205,7 @@ func runStoryUpdate(cmd *cobra.Command, args []string) error {
 		VStatus:       flagStatus,
 		Owner:         flagOwner,
 		PriorityLabel: flagPriority,
+		IterationID:   flagIterationID,
 	}
 	story, err := apiClient.UpdateStory(context.Background(), req)
 	if err != nil {

--- a/internal/cmd/story_test.go
+++ b/internal/cmd/story_test.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	tapd "github.com/studyzy/tapd-sdk-go"
+)
+
+func TestBuildSpecLines_StoryUpdateIncludesIterationID(t *testing.T) {
+	lines := buildSpecLines(rootCmd)
+	for _, line := range lines {
+		if extractCommandPath(line.text) != "tapd story update" {
+			continue
+		}
+		if !strings.Contains(line.text, "[--iteration-id]") {
+			t.Fatalf("story update spec line should contain iteration flag, got: %s", line.text)
+		}
+		return
+	}
+
+	t.Fatal("tapd story update spec line not found")
+}
+
+func TestRunStoryUpdate_PassesIterationID(t *testing.T) {
+	t.Helper()
+
+	oldClient := apiClient
+	oldWorkspaceID := flagWorkspaceID
+	oldPretty := flagPretty
+	oldName := flagName
+	oldDescription := flagDescription
+	oldStatus := flagStatus
+	oldOwner := flagOwner
+	oldPriority := flagPriority
+	oldIterationID := flagIterationID
+	oldStdout := os.Stdout
+
+	t.Cleanup(func() {
+		apiClient = oldClient
+		flagWorkspaceID = oldWorkspaceID
+		flagPretty = oldPretty
+		flagName = oldName
+		flagDescription = oldDescription
+		flagStatus = oldStatus
+		flagOwner = oldOwner
+		flagPriority = oldPriority
+		flagIterationID = oldIterationID
+		os.Stdout = oldStdout
+	})
+
+	var captured url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/stories" {
+			t.Fatalf("expected path /stories, got %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		captured = r.PostForm
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":1,"data":{"Story":{"id":"10001","name":"Updated"}},"info":"success"}`))
+	}))
+	defer srv.Close()
+
+	apiClient = tapd.NewClientWithBaseURL(srv.URL, srv.URL, "test-token", "", "")
+	flagWorkspaceID = "51081496"
+	flagName = "更新后的需求"
+	flagDescription = "新的描述"
+	flagStatus = "进行中"
+	flagOwner = "alice"
+	flagPriority = "High"
+	flagIterationID = "123"
+	flagPretty = false
+
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe failed: %v", err)
+	}
+	os.Stdout = stdoutWriter
+
+	runErr := runStoryUpdate(nil, []string{"10001"})
+	_ = stdoutWriter.Close()
+	os.Stdout = oldStdout
+
+	if runErr != nil {
+		t.Fatalf("runStoryUpdate returned error: %v", runErr)
+	}
+	if _, err := io.ReadAll(stdoutReader); err != nil {
+		t.Fatalf("failed to read stdout: %v", err)
+	}
+	_ = stdoutReader.Close()
+
+	if got := captured.Get("workspace_id"); got != "51081496" {
+		t.Fatalf("workspace_id = %q, want %q", got, "51081496")
+	}
+	if got := captured.Get("id"); got != "10001" {
+		t.Fatalf("id = %q, want %q", got, "10001")
+	}
+	if got := captured.Get("iteration_id"); got != "123" {
+		t.Fatalf("iteration_id = %q, want %q", got, "123")
+	}
+	if got := captured.Get("v_status"); got != "进行中" {
+		t.Fatalf("v_status = %q, want %q", got, "进行中")
+	}
+	if got := captured.Get("description"); got == "" {
+		t.Fatal("description should be converted and sent when provided")
+	}
+}
+
+func TestStoryUpdateFlagRegistered(t *testing.T) {
+	flag := storyUpdateCmd.Flags().Lookup("iteration-id")
+	if flag == nil {
+		t.Fatal("story update should register --iteration-id")
+	}
+	if flag.Usage != "新迭代 ID" {
+		t.Fatalf("iteration-id usage = %q, want %q", flag.Usage, "新迭代 ID")
+	}
+}


### PR DESCRIPTION
## Summary
- add `--iteration-id` to `tapd story update`
- pass the iteration id through to `UpdateStoryRequest`
- add tests and a README example

## Background
- the TAPD SDK already supports `UpdateStoryRequest.IterationID`, but the CLI did not expose it on `tapd story update`

## Changes
- register `--iteration-id` on the story update command
- include `IterationID` when building the update request
- verify help/spec output and request mapping in tests

## Test Plan
- run `go test ./...`

## Risks
- only supports setting or changing an iteration id
- does not add a separate clear-iteration flow

#1 
