### PR TITLE
feat(bug update): add --owner flag to reassign current_owner (#3)

### DIFF
--- a/internal/cmd/bug.go
+++ b/internal/cmd/bug.go
@@ -88,6 +88,7 @@ func init() {
 	bugUpdateCmd.Flags().StringVar(&flagStatus, "status", "", "新状态（用 workflow status-map 查询可用值）")
 	bugUpdateCmd.Flags().StringVar(&flagPriority, "priority", "", "新优先级（urgent/high/medium/low/insignificant）")
 	bugUpdateCmd.Flags().StringVar(&flagSeverity, "severity", "", "新严重程度（fatal/serious/normal/prompt/advice）")
+	bugUpdateCmd.Flags().StringVar(&flagOwner, "owner", "", "新处理人（current_owner）")
 
 	bugCountCmd.Flags().StringVar(&flagStatus, "status", "", "按状态筛选（用 workflow status-map 查询可用值）")
 
@@ -193,6 +194,7 @@ func runBugUpdate(cmd *cobra.Command, args []string) error {
 		VStatus:       flagStatus,
 		PriorityLabel: flagPriority,
 		Severity:      flagSeverity,
+		CurrentOwner:  flagOwner,
 	}
 	bug, err := apiClient.UpdateBug(context.Background(), req)
 	if err != nil {


### PR DESCRIPTION
## Summary

\`tapd bug update\` couldn't change a bug's \`current_owner\` even though the underlying SDK's \`UpdateBugRequest\` already exposes \`CurrentOwner\` — a common triage action (reassign to the tester after fixing) required writing a one-off Go program. \`tapd story update\` already supports \`--owner\`, so the inconsistency was purely at the CLI layer.

## Fix

- Register \`--owner\` on \`bugUpdateCmd\` with the same \"新处理人\" help text style used by the story update command.
- Wire the flag into \`UpdateBugRequest.CurrentOwner\`.

Empty \`--owner\` means \"no change\" because the SDK's \`ToParams\` omits blank strings, matching the existing field behaviour.

Fixes #3

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] Verified \`CurrentOwner\` is already supported in the installed \`tapd-sdk-go\` v0.6.0 (\`model/bug.go:446\`) so no SDK bump is needed.