### PR TITLE
fix(cli): wire expandShortID into bug/story/task show & update

### DIFF
--- a/internal/cmd/bug.go
+++ b/internal/cmd/bug.go
@@ -33,6 +33,7 @@ var bugListCmd = &cobra.Command{
 var bugShowCmd = &cobra.Command{
 	Use:   "show <bug_id>",
 	Short: "查看缺陷详情",
+	Long:  "查看缺陷详情。<bug_id> 支持 TAPD 长 ID，或 ≤9 位的短号（短号会按当前 workspace 自动展开）。",
 	Args:  cobra.ExactArgs(1),
 	RunE:  runBugShow,
 }
@@ -50,7 +51,8 @@ var bugCreateCmd = &cobra.Command{
 var bugUpdateCmd = &cobra.Command{
 	Use:   "update <bug_id>",
 	Short: "更新缺陷",
-	Long: `更新缺陷，描述支持三种输入方式：
+	Long: `更新缺陷。<bug_id> 支持 TAPD 长 ID，或 ≤9 位的短号（短号会按当前 workspace 自动展开）。
+描述支持三种输入方式：
   1. --description <text>  直接传入描述文本
   2. --file <path>         从本地文件读取描述内容
   3. echo "..." | tapd bug update <bug_id>  通过 stdin 管道输入`,
@@ -169,7 +171,9 @@ func runBugList(cmd *cobra.Command, args []string) error {
 }
 
 func runBugShow(cmd *cobra.Command, args []string) error {
-	bug, err := apiClient.GetBug(context.Background(), flagWorkspaceID, args[0])
+	// 短号自动展开为 TAPD 长 ID，向 SDK / printComments 传同一个展开后的 id
+	id := expandShortID(args[0], flagWorkspaceID)
+	bug, err := apiClient.GetBug(context.Background(), flagWorkspaceID, id)
 	if err != nil {
 		output.PrintError(os.Stderr, "api_error", err.Error(), "")
 		os.Exit(output.ExitAPIError)
@@ -179,7 +183,7 @@ func runBugShow(cmd *cobra.Command, args []string) error {
 	if err := printDetail(bug, "description"); err != nil {
 		return err
 	}
-	printComments(flagWorkspaceID, "bug", args[0])
+	printComments(flagWorkspaceID, "bug", id)
 	return nil
 }
 
@@ -230,9 +234,11 @@ func runBugUpdate(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// 短号自动展开为 TAPD 长 ID
+	id := expandShortID(args[0], flagWorkspaceID)
 	req := &model.UpdateBugRequest{
 		WorkspaceID:   flagWorkspaceID,
-		ID:            args[0],
+		ID:            id,
 		Title:         flagTitle,
 		Description:   description,
 		VStatus:       flagStatus,

--- a/internal/cmd/id_expand_wiring_test.go
+++ b/internal/cmd/id_expand_wiring_test.go
@@ -1,0 +1,183 @@
+// Package cmd 中的 id_expand_wiring_test.go 验证 show / update 命令在调用 SDK 前
+// 已经把短 ID 展开为 TAPD 长 ID（即把短号 28841 + workspace 12345 → 1112345000028841 再发请求）。
+// 这些测试拦截 HTTP 请求并断言出栈到 SDK 的 id 参数已经是展开后的长 ID。
+package cmd
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// captureIDs 记录每次非 /comments 请求中的 id：
+//   - GET（show 系列）从 URL query 取
+//   - POST（update 系列）从表单体取
+// /comments 请求单独记录 entry_id，便于断言 printComments 也用了展开后的 ID
+type captureIDs struct {
+	mainID    string // GetBug/GetStory/GetTask 或 UpdateXxx 收到的 id
+	commentID string // ListComments 收到的 entry_id
+}
+
+// captureHandler 返回一个测试服务器 handler，写入 caps 同时回一份合法响应让 handler 流程跑完
+func captureHandler(t *testing.T, entity string, caps *captureIDs) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if strings.Contains(path, "/comments") {
+			caps.commentID = r.URL.Query().Get("entry_id")
+			w.Write([]byte(`{"status":1,"data":[]}`))
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			caps.mainID = r.URL.Query().Get("id")
+			// GET (show/list) 返回数组 shape
+			w.Write([]byte(`{"status":1,"data":[{"` + entity + `":{"id":"placeholder","title":"x","name":"x"}}]}`))
+		case http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			form, _ := url.ParseQuery(string(body))
+			caps.mainID = form.Get("id")
+			// POST (update) 返回单对象 shape
+			w.Write([]byte(`{"status":1,"data":{"` + entity + `":{"id":"placeholder","title":"x","name":"x"}}}`))
+		}
+	}
+}
+
+func TestRunBugShow_ExpandsShortID(t *testing.T) {
+	resetFlags()
+	var caps captureIDs
+	_, cleanup := setupMockServer(t, captureHandler(t, "Bug", &caps))
+	defer cleanup()
+	flagJSON = true
+	flagNoComments = false // 让 printComments 被实际触发，以验证它也用了展开后的 ID
+
+	restore, reader := captureStdout(t)
+	if err := runBugShow(nil, []string{"28841"}); err != nil {
+		t.Fatalf("runBugShow returned error: %v", err)
+	}
+	restore()
+	drainReader(reader)
+
+	// setupMockServer 固定 workspaceID = "12345"，按 expandShortID 规则：
+	// "11" + "12345" + 左补零到 9 位的 "28841" = "1112345000028841"
+	const wantID = "1112345000028841"
+	if caps.mainID != wantID {
+		t.Errorf("GetBug received id=%q, want %q (短号未被展开)", caps.mainID, wantID)
+	}
+	if caps.commentID != wantID {
+		t.Errorf("printComments received entry_id=%q, want %q (短号未被展开)", caps.commentID, wantID)
+	}
+}
+
+func TestRunStoryShow_ExpandsShortID(t *testing.T) {
+	resetFlags()
+	var caps captureIDs
+	_, cleanup := setupMockServer(t, captureHandler(t, "Story", &caps))
+	defer cleanup()
+	flagJSON = true
+	flagNoComments = false
+
+	restore, reader := captureStdout(t)
+	if err := runStoryShow(nil, []string{"28841"}); err != nil {
+		t.Fatalf("runStoryShow returned error: %v", err)
+	}
+	restore()
+	drainReader(reader)
+
+	const wantID = "1112345000028841"
+	if caps.mainID != wantID {
+		t.Errorf("GetStory received id=%q, want %q (短号未被展开)", caps.mainID, wantID)
+	}
+	if caps.commentID != wantID {
+		t.Errorf("printComments received entry_id=%q, want %q (短号未被展开)", caps.commentID, wantID)
+	}
+}
+
+func TestRunTaskShow_ExpandsShortID(t *testing.T) {
+	resetFlags()
+	var caps captureIDs
+	_, cleanup := setupMockServer(t, captureHandler(t, "Task", &caps))
+	defer cleanup()
+	flagJSON = true
+	flagNoComments = false
+
+	restore, reader := captureStdout(t)
+	if err := runTaskShow(nil, []string{"28841"}); err != nil {
+		t.Fatalf("runTaskShow returned error: %v", err)
+	}
+	restore()
+	drainReader(reader)
+
+	const wantID = "1112345000028841"
+	if caps.mainID != wantID {
+		t.Errorf("GetTask received id=%q, want %q (短号未被展开)", caps.mainID, wantID)
+	}
+	if caps.commentID != wantID {
+		t.Errorf("printComments received entry_id=%q, want %q (短号未被展开)", caps.commentID, wantID)
+	}
+}
+
+func TestRunBugUpdate_ExpandsShortID(t *testing.T) {
+	resetFlags()
+	var caps captureIDs
+	_, cleanup := setupMockServer(t, captureHandler(t, "Bug", &caps))
+	defer cleanup()
+	flagJSON = true
+	flagTitle = "x" // 给 update 一个非空字段以确保 SDK 真的发请求
+
+	restore, reader := captureStdout(t)
+	if err := runBugUpdate(nil, []string{"28841"}); err != nil {
+		t.Fatalf("runBugUpdate returned error: %v", err)
+	}
+	restore()
+	drainReader(reader)
+
+	const wantID = "1112345000028841"
+	if caps.mainID != wantID {
+		t.Errorf("UpdateBug received id=%q, want %q (短号未被展开)", caps.mainID, wantID)
+	}
+}
+
+func TestRunStoryUpdate_ExpandsShortID(t *testing.T) {
+	resetFlags()
+	var caps captureIDs
+	_, cleanup := setupMockServer(t, captureHandler(t, "Story", &caps))
+	defer cleanup()
+	flagJSON = true
+	flagName = "x"
+
+	restore, reader := captureStdout(t)
+	if err := runStoryUpdate(nil, []string{"28841"}); err != nil {
+		t.Fatalf("runStoryUpdate returned error: %v", err)
+	}
+	restore()
+	drainReader(reader)
+
+	const wantID = "1112345000028841"
+	if caps.mainID != wantID {
+		t.Errorf("UpdateStory received id=%q, want %q (短号未被展开)", caps.mainID, wantID)
+	}
+}
+
+func TestRunTaskUpdate_ExpandsShortID(t *testing.T) {
+	resetFlags()
+	var caps captureIDs
+	_, cleanup := setupMockServer(t, captureHandler(t, "Task", &caps))
+	defer cleanup()
+	flagJSON = true
+	flagName = "x"
+
+	restore, reader := captureStdout(t)
+	if err := runTaskUpdate(nil, []string{"28841"}); err != nil {
+		t.Fatalf("runTaskUpdate returned error: %v", err)
+	}
+	restore()
+	drainReader(reader)
+
+	const wantID = "1112345000028841"
+	if caps.mainID != wantID {
+		t.Errorf("UpdateTask received id=%q, want %q (短号未被展开)", caps.mainID, wantID)
+	}
+}

--- a/internal/cmd/story.go
+++ b/internal/cmd/story.go
@@ -51,6 +51,7 @@ var storyListCmd = &cobra.Command{
 var storyShowCmd = &cobra.Command{
 	Use:   "show <story_id>",
 	Short: "查看需求详情",
+	Long:  "查看需求详情。<story_id> 支持 TAPD 长 ID，或 ≤9 位的短号（短号会按当前 workspace 自动展开）。",
 	Args:  cobra.ExactArgs(1),
 	RunE:  runStoryShow,
 }
@@ -68,7 +69,8 @@ var storyCreateCmd = &cobra.Command{
 var storyUpdateCmd = &cobra.Command{
 	Use:   "update <story_id>",
 	Short: "更新需求",
-	Long: `更新需求，描述支持三种输入方式：
+	Long: `更新需求。<story_id> 支持 TAPD 长 ID，或 ≤9 位的短号（短号会按当前 workspace 自动展开）。
+描述支持三种输入方式：
   1. --description <text>  直接传入描述文本
   2. --file <path>         从本地文件读取描述内容
   3. echo "..." | tapd story update <story_id>  通过 stdin 管道输入`,
@@ -183,7 +185,9 @@ func runStoryList(cmd *cobra.Command, args []string) error {
 }
 
 func runStoryShow(cmd *cobra.Command, args []string) error {
-	story, err := apiClient.GetStory(context.Background(), flagWorkspaceID, args[0])
+	// 短号自动展开为 TAPD 长 ID，向 SDK / printComments 传同一个展开后的 id
+	id := expandShortID(args[0], flagWorkspaceID)
+	story, err := apiClient.GetStory(context.Background(), flagWorkspaceID, id)
 	if err != nil {
 		output.PrintError(os.Stderr, "api_error", err.Error(), "")
 		os.Exit(output.ExitAPIError)
@@ -193,7 +197,7 @@ func runStoryShow(cmd *cobra.Command, args []string) error {
 	if err := printDetail(story, "description"); err != nil {
 		return err
 	}
-	printComments(flagWorkspaceID, "stories", args[0])
+	printComments(flagWorkspaceID, "stories", id)
 	return nil
 }
 
@@ -245,9 +249,11 @@ func runStoryUpdate(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// 短号自动展开为 TAPD 长 ID
+	id := expandShortID(args[0], flagWorkspaceID)
 	req := &model.UpdateStoryRequest{
 		WorkspaceID:   flagWorkspaceID,
-		ID:            args[0],
+		ID:            id,
 		Name:          flagName,
 		Description:   description,
 		VStatus:       flagStatus,

--- a/internal/cmd/story_test.go
+++ b/internal/cmd/story_test.go
@@ -102,8 +102,9 @@ func TestRunStoryUpdate_PassesIterationID(t *testing.T) {
 	if got := captured.Get("workspace_id"); got != "51081496" {
 		t.Fatalf("workspace_id = %q, want %q", got, "51081496")
 	}
-	if got := captured.Get("id"); got != "10001" {
-		t.Fatalf("id = %q, want %q", got, "10001")
+	// 短号 10001 + workspace 51081496 经 expandShortID 展开为 11 + 51081496 + 000010001
+	if got := captured.Get("id"); got != "1151081496000010001" {
+		t.Fatalf("id = %q, want %q", got, "1151081496000010001")
 	}
 	if got := captured.Get("iteration_id"); got != "123" {
 		t.Fatalf("iteration_id = %q, want %q", got, "123")

--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -28,6 +28,7 @@ var taskListCmd = &cobra.Command{
 var taskShowCmd = &cobra.Command{
 	Use:   "show <task_id>",
 	Short: "查看任务详情",
+	Long:  "查看任务详情。<task_id> 支持 TAPD 长 ID，或 ≤9 位的短号（短号会按当前 workspace 自动展开）。",
 	Args:  cobra.ExactArgs(1),
 	RunE:  runTaskShow,
 }
@@ -45,7 +46,8 @@ var taskCreateCmd = &cobra.Command{
 var taskUpdateCmd = &cobra.Command{
 	Use:   "update <task_id>",
 	Short: "更新任务",
-	Long: `更新任务，描述支持三种输入方式：
+	Long: `更新任务。<task_id> 支持 TAPD 长 ID，或 ≤9 位的短号（短号会按当前 workspace 自动展开）。
+描述支持三种输入方式：
   1. --description <text>  直接传入描述文本
   2. --file <path>         从本地文件读取描述内容
   3. echo "..." | tapd task update <task_id>  通过 stdin 管道输入`,
@@ -159,7 +161,9 @@ func runTaskList(cmd *cobra.Command, args []string) error {
 }
 
 func runTaskShow(cmd *cobra.Command, args []string) error {
-	task, err := apiClient.GetTask(context.Background(), flagWorkspaceID, args[0])
+	// 短号自动展开为 TAPD 长 ID，向 SDK / printComments 传同一个展开后的 id
+	id := expandShortID(args[0], flagWorkspaceID)
+	task, err := apiClient.GetTask(context.Background(), flagWorkspaceID, id)
 	if err != nil {
 		output.PrintError(os.Stderr, "api_error", err.Error(), "")
 		os.Exit(output.ExitAPIError)
@@ -169,7 +173,7 @@ func runTaskShow(cmd *cobra.Command, args []string) error {
 	if err := printDetail(task, "description"); err != nil {
 		return err
 	}
-	printComments(flagWorkspaceID, "tasks", args[0])
+	printComments(flagWorkspaceID, "tasks", id)
 	return nil
 }
 
@@ -220,9 +224,11 @@ func runTaskUpdate(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// 短号自动展开为 TAPD 长 ID
+	id := expandShortID(args[0], flagWorkspaceID)
 	req := &model.UpdateTaskRequest{
 		WorkspaceID:   flagWorkspaceID,
-		ID:            args[0],
+		ID:            id,
 		Name:          flagName,
 		Description:   description,
 		Status:        flagStatus,


### PR DESCRIPTION
## Symptom

`tapd bug show 1007317` (and the equivalent story/task `show`, plus
`bug`/`story`/`task update`) returns `{"error":"api_error","message":"bug 1007317 not found"}` whenever the user passes a TAPD **short number** instead of the 19-digit long ID.

## Root cause

The helper `expandShortID` (`internal/cmd/id_expand.go`) and its unit tests are already in place — but **no command handler ever calls it**. The raw `args[0]` is passed straight to the SDK, which forwards it as `id=<short>` to the TAPD API, which then matches nothing.

```
$ grep -rn "expandShortID" internal/
internal/cmd/id_expand.go:9: …
internal/cmd/id_expand_test.go: …   ← only tests
```

## Fix

Wire `expandShortID(args[0], flagWorkspaceID)` into the six affected handlers so the SDK call **and** the downstream `printComments` call both see the expanded long ID:

- `runBugShow` / `runBugUpdate`
- `runStoryShow` / `runStoryUpdate`
- `runTaskShow` / `runTaskUpdate`

Scope is intentionally limited to story/bug/task — these are the entities with a user-facing short number. `comment` / `iteration` / `timesheet` / `wiki` IDs are produced by `list` output as long IDs and are intentionally left untouched.

## Tests

- New `internal/cmd/id_expand_wiring_test.go` spins up an `httptest.Server`, captures the outgoing HTTP `id` (and `entry_id` for `printComments`), and asserts the long form was sent. Covers all six handlers — 6 new test cases.
- Existing `TestRunStoryUpdate_PassesIterationID` asserted on the pre-expansion id; updated to the expanded value with a comment explaining the rule.

`go test ./...` and `go vet ./...` both clean.

## Docs

`Long:` text on `bug/story/task show` and `bug/story/task update` now documents short-ID support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)