### PR TITLE
feat(bug): `bug update` 返回 current_status & current_owner

### DIFF
--- a/internal/cmd/bug.go
+++ b/internal/cmd/bug.go
@@ -255,7 +255,21 @@ func runBugUpdate(cmd *cobra.Command, args []string) error {
 		os.Exit(output.ExitAPIError)
 		return nil
 	}
-	return printSuccessResponse(bug.ID, fmt.Sprintf("%s/%s/bugtrace/bugs/view/%s", apiClient.WebURL(), flagWorkspaceID, bug.ID), "")
+
+	// 把服务端返回的"更新后实际状态/处理人"一并吐进成功输出：
+	// TAPD 的 update 接口会回传更新后的工单对象，bug.Status / bug.CurrentOwner
+	// 即服务端实际生效的值。调用方据此即可确认状态已落地，无需再 `bug show` 验一次（省 TAPD API）。
+	// 若请求了 status 但返回值不符（workflow 拒绝该流转 / 缺 resolution 等），打 warning 提醒。
+	if flagStatus != "" && bug.Status != "" && bug.Status != flagStatus {
+		fmt.Fprintf(os.Stderr, "WARNING: 请求 status=%s，但服务端返回 status=%s（流转可能未生效，检查 workflow / resolution 等必填项）\n", flagStatus, bug.Status)
+	}
+	return output.PrintJSON(os.Stdout, map[string]interface{}{
+		"success":        true,
+		"id":             bug.ID,
+		"url":            fmt.Sprintf("%s/%s/bugtrace/bugs/view/%s", apiClient.WebURL(), flagWorkspaceID, bug.ID),
+		"current_status": bug.Status,
+		"current_owner":  bug.CurrentOwner,
+	}, !flagPretty)
 }
 
 func runBugCount(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## 背景

TAPD 的 update 接口（`POST /bugs`）会回传更新后的工单对象，但 `tapd bug update` 此前只输出 `id`/`url`，把服务端实际生效的 `status` / `current_owner` 丢弃了。

这导致调用方（脚本 / AI agent）改完状态后，只能再发一次 `tapd bug show` 去确认状态是否真的生效——而 `bug show` 默认还会附带一次 `ListComments`，等于每次确认要多打 **2 个** TAPD API 请求。TAPD 有 2000 请求/24h 的限流，批量场景下很容易撞穿。

## 改动

`runBugUpdate` 在成功时输出带上 `current_status` + `current_owner`（取自 `UpdateBug` 的返回对象），调用方据此即可确认状态已落地，**无需再 `bug show` 一次**。

此外，当请求了 `--status` 但服务端返回的状态与之不符时（workflow 拒绝该流转 / 缺 `resolution` 等），向 stderr 打一条 `WARNING`，避免「update 返回 success 但状态没变」的静默脏状态。

## 输出示例

```json
{
  "success": true,
  "id": "1140xxxxxxxxxx",
  "url": "https://www.tapd.cn/.../bugs/view/1140xxxxxxxxxx",
  "current_status": "resolved",
  "current_owner": "张三"
}
```

## 兼容性

- 仅给成功输出**新增**字段，不改动既有 `id`/`url`/`success`，对现有调用方无破坏。
- 已用上游 SDK `studyzy/tapd-sdk-go v0.6.0` `go build ./...` 通过（`model.Bug` 的 `Status`/`CurrentOwner` 字段上游已有）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)